### PR TITLE
build: Ship xdg-utils into the bundle

### DIFF
--- a/com.mojang.Minecraft.json
+++ b/com.mojang.Minecraft.json
@@ -40,6 +40,31 @@
           ]
       },
       {
+          "name": "xmlto",
+          "cleanup-platform": [ "*" ],
+          "no-autogen": true,
+          "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://fedorahosted.org/releases/x/m/xmlto/xmlto-0.0.28.tar.gz",
+                    "sha256": "2f986b7c9a0e9ac6728147668e776d405465284e13c74d4146c9cbc51fd8aad3"
+                }
+          ]
+        },
+        {
+          "name": "xdg-utils",
+          "sources": [
+              {
+                  "type": "git",
+                  "url": "git://anongit.freedesktop.org/xdg/xdg-utils"
+              },
+              {
+                  "type": "patch",
+                  "path": "xdg-utils-no-lynx-dependency.patch"
+              }
+          ]
+      },
+      {
           "name": "minecraft",
           "no-autogen": true,
           "sources" : [

--- a/xdg-utils-no-lynx-dependency.patch
+++ b/xdg-utils-no-lynx-dependency.patch
@@ -1,0 +1,103 @@
+From ff5c476fa65539ac5b4590275198360c83af137f Mon Sep 17 00:00:00 2001
+From: Matt Watson <mattdangerw@gmail.com>
+Date: Fri, 25 Nov 2016 01:40:40 -0800
+Subject: [PATCH] Makefile: don't generate a txt file from xml
+
+This requires bringing in lynx, a dependency we are trying to
+avoid.
+
+This does mean that usage and examples won't be built in to the
+commands.
+---
+ scripts/Makefile.in              |  6 +----
+ scripts/generate-help-script.awk | 53 ----------------------------------------
+ 2 files changed, 1 insertion(+), 58 deletions(-)
+
+diff --git a/scripts/Makefile.in b/scripts/Makefile.in
+index d167393..cdc2e4a 100644
+--- a/scripts/Makefile.in
++++ b/scripts/Makefile.in
+@@ -81,7 +81,7 @@ uninstall:
+ 	done
+ 	-$(RMDIR) $(DESTDIR)$(bindir)
+ 
+-%: %.in %.txt
++%: %.in
+ 	awk -f generate-help-script.awk $@.in | sed -e 's/@NAME@/'$@'/g' > $@
+ 	chmod a+x $@
+ 
+@@ -109,7 +109,3 @@ html/index.html: $(XMLFILES)
+ 
+ html/%.html: desc/%.xml
+ 	(cd html;$(XMLTO) html-nochunks ../$<)
+-
+-%.txt: desc/%.xml
+-	$(XMLTO) txt $<
+-
+diff --git a/scripts/generate-help-script.awk b/scripts/generate-help-script.awk
+index d4bf76e..6cdb2d2 100644
+--- a/scripts/generate-help-script.awk
++++ b/scripts/generate-help-script.awk
+@@ -46,59 +46,6 @@
+ }
+ 
+ 
+-# Insert the examples text from the .txt file
+-# after the "cat << _MANUALPAGE" line
+-/^cat << _MANUALPAGE/ {
+-	# determine the name of the .txt file
+-	txtfile = FILENAME
+-	sub(/\.in$/, ".txt", txtfile)
+-
+-	# read the .txt file content
+-	for (txtfile_print = 0; getline < txtfile; ) {
+-#		if (match ($0, /^Examples/) != 0) {
+-#			# print everything starting at the "Examples" line
+-#			txtfile_print = 1
+-#		}
+-#		if (txtfile_print != 0) {
+-#			print $0
+-#		}
+-                gsub("`","'")
+-                gsub("—","-")
+-                print $0
+-	}
+-	close (txtfile)
+-}
+-
+-
+-# Insert the usage text from the .txt file
+-# after the "cat << _USAGE" line
+-/^cat << _USAGE/ {
+-	# determine the name of the .txt file
+-	txtfile = FILENAME
+-	sub(/\.in$/, ".txt", txtfile)
+-
+-	# read the .txt file content
+-	for (txtfile_print = 0; getline < txtfile; ) {
+-		if (match ($0, /^Name/) != 0) {
+-			# skip empty line after "Name"
+-			getline < txtfile
+-
+-			# from now on, print everything
+-			txtfile_print = 1
+-		}
+-		else if (match ($0, /^Description/) != 0) {
+-			# stop at "Description"
+-			break
+-		}
+-		else if (txtfile_print != 0) {
+-	                gsub("—","-")
+-			print $0
+-		}
+-	}
+-	close (txtfile)
+-}
+-
+-
+ # Insert the xdg-utils-common.in content after
+ # the "#@xdg-utils-common@" line
+ /^#@xdg-utils-common@/ {
+-- 
+2.1.4
+


### PR DESCRIPTION
The 'register' link needs xdg-open which is not yet
provided by the GNOME runtime.

https://phabricator.endlessm.com/T15344